### PR TITLE
Skip non-lua files

### DIFF
--- a/pyStormworksLuaInject/__main__.py
+++ b/pyStormworksLuaInject/__main__.py
@@ -59,6 +59,11 @@ def main():
     data = open(root_path+outfile).read()
 
     for file in os.scandir(sys.argv[2]):
+         #skip non-lua files (.DS_Store is a hidden file created in all folders on macOS, code will fail trying to read it)
+        if not file.name.endswith('.lua'):
+            print(f"Skipping file: {file.name}")
+            continue
+            
         code = open(file.path).read()
         identifier = file.name[:file.name.rindex('.')]
         print(f"Searching '{outfile}' for Lua blocks with identifier '{identifier}'")


### PR DESCRIPTION
When a file system is scanned and a file other than expected (.lua) is found, code will fail. I suggest only reading .lua files to avoid errors (skip all non-lua files)